### PR TITLE
[WIP] Arch PKGBUILD

### DIFF
--- a/packaging/linux/.gitignore
+++ b/packaging/linux/.gitignore
@@ -1,0 +1,4 @@
+/src
+/pkg
+/*pkg.tar.*
+/*.tar.gz

--- a/packaging/linux/PKGBUILD
+++ b/packaging/linux/PKGBUILD
@@ -19,7 +19,7 @@ source=(
 md5sums=('7c841a575cb1d64db6ddf0bd82c5bebb'
          '41fab13ca2b0f4f379a1974bd6ba2517'
          '36404aac1598ba82f7fbcae2a3736a55'
-         '515a0565755bc7e4c80b3f134e35e113')
+         '08c4c18e02a87bb8965cef0410266635')
 
 build() {
     export CC=clang

--- a/packaging/linux/PKGBUILD
+++ b/packaging/linux/PKGBUILD
@@ -9,7 +9,7 @@ license=("BSD")
 depends=("imagemagick" "gtk3" "sdl2" "sdl2_mixer" "glew" "openal")
 makedepends=("clang" "cmake" "bison" "python-cogapp")
 checkdepends=()
-optdepends=("innoextract: installing game data from GOOG release")
+optdepends=("innoextract: installing game data from GOG release")
 backup=()
 source=(
     "$pkgname-$pkgver.tar.gz::https://github.com/shinyquagsire23/OpenJKDF2/archive/refs/tags/v$pkgver.tar.gz"

--- a/packaging/linux/PKGBUILD
+++ b/packaging/linux/PKGBUILD
@@ -1,0 +1,23 @@
+pkgname="openjkdf2"
+pkgver=0.3.1
+pkgrel=1
+epoch=
+pkgdesc="A cross-platform reimplementation of Jedi Knight: Dark Forces II"
+arch=("x86_64" "aarch64")
+url="https://github.com/shinyquagsire23/OpenJKDF2"
+license=("custom")
+depends=("imagemagick" "gtk3")
+makedepends=("cmake" "bison" "python-cogapp")
+checkdepends=()
+optdepends=()
+backup=()
+source=("openjkdf2-$pkgver.tar.gz::https://github.com/shinyquagsire23/OpenJKDF2/archive/refs/tags/v$pkgver.tar.gz")
+md5sums=('7c841a575cb1d64db6ddf0bd82c5bebb')
+
+build() {
+    echo "TODO"
+}
+
+package() {
+    echo "TODO"
+}

--- a/packaging/linux/PKGBUILD
+++ b/packaging/linux/PKGBUILD
@@ -6,18 +6,24 @@ pkgdesc="A cross-platform reimplementation of Jedi Knight: Dark Forces II"
 arch=("x86_64" "aarch64")
 url="https://github.com/shinyquagsire23/OpenJKDF2"
 license=("BSD")
-depends=("imagemagick" "gtk3")
-makedepends=("cmake" "bison" "python-cogapp")
+depends=("imagemagick" "gtk3" "sdl2" "sdl2_mixer" "glew" "openal")
+makedepends=("clang" "cmake" "bison" "python-cogapp")
 checkdepends=()
-optdepends=()
+optdepends=("innoextract: installing game data from GOOG release")
 backup=()
 source=(
     "$pkgname-$pkgver.tar.gz::https://github.com/shinyquagsire23/OpenJKDF2/archive/refs/tags/v$pkgver.tar.gz"
-    "openjkdf2.desktop")
+    "openjkdf2.desktop"
+    "openjkdf2.sh"
+    "openjkdf2_import.sh")
 md5sums=('7c841a575cb1d64db6ddf0bd82c5bebb'
-         '41fab13ca2b0f4f379a1974bd6ba2517')
+         '41fab13ca2b0f4f379a1974bd6ba2517'
+         '36404aac1598ba82f7fbcae2a3736a55'
+         '515a0565755bc7e4c80b3f134e35e113')
 
 build() {
+    export CC=clang
+    export CXX=clang++
     cd "$srcdir/OpenJKDF2-$pkgver"
     cmake .
     make
@@ -25,10 +31,13 @@ build() {
 
 package() {
     cd "$srcdir/OpenJKDF2-$pkgver"
-    install -DT "openjkdf2-64" "$pkgdir/usr/bin/openjkdf2"
     install -DTm644 "packaging/icon.png" "$pkgdir/usr/share/pixmaps/$pkgname.png"
     install -Dm644 -t "$pkgdir/usr/share/licenses/$pkgname" "LICENSE.md"
     install -Dm644 -t "$pkgdir/usr/share/doc/$pkgname" "README.md"
     install -Dm644 -t "$pkgdir/usr/share/doc/$pkgname/docs/images" "docs/images/"*
     install -Dm644 -t "$pkgdir/usr/share/applications" "../$pkgname.desktop"
+    install -Dm644 -t "$pkgdir/usr/share/$pkgname/resource/shaders" "resource/shaders/"*
+    install -D -t "$pkgdir/usr/share/$pkgname" "openjkdf2-64"
+    install -DT "../openjkdf2.sh" "$pkgdir/usr/bin/openjkdf2"
+    install -DT "../openjkdf2_import.sh" "$pkgdir/usr/bin/openjkdf2_import"
 }

--- a/packaging/linux/PKGBUILD
+++ b/packaging/linux/PKGBUILD
@@ -26,7 +26,7 @@ build() {
 package() {
     cd "$srcdir/OpenJKDF2-$pkgver"
     install -DT "openjkdf2-64" "$pkgdir/usr/bin/openjkdf2"
-    install -DTm644 "packaging/icon.png" "$pkgdir/usr/share/icons/hicolor/1024x1024/apps/$pkgname.png"
+    install -DTm644 "packaging/icon.png" "$pkgdir/usr/share/pixmaps/$pkgname.png"
     install -Dm644 -t "$pkgdir/usr/share/licenses/$pkgname" "LICENSE.md"
     install -Dm644 -t "$pkgdir/usr/share/doc/$pkgname" "README.md"
     install -Dm644 -t "$pkgdir/usr/share/doc/$pkgname/docs/images" "docs/images/"*

--- a/packaging/linux/PKGBUILD
+++ b/packaging/linux/PKGBUILD
@@ -5,19 +5,30 @@ epoch=
 pkgdesc="A cross-platform reimplementation of Jedi Knight: Dark Forces II"
 arch=("x86_64" "aarch64")
 url="https://github.com/shinyquagsire23/OpenJKDF2"
-license=("custom")
+license=("BSD")
 depends=("imagemagick" "gtk3")
 makedepends=("cmake" "bison" "python-cogapp")
 checkdepends=()
 optdepends=()
 backup=()
-source=("openjkdf2-$pkgver.tar.gz::https://github.com/shinyquagsire23/OpenJKDF2/archive/refs/tags/v$pkgver.tar.gz")
-md5sums=('7c841a575cb1d64db6ddf0bd82c5bebb')
+source=(
+    "$pkgname-$pkgver.tar.gz::https://github.com/shinyquagsire23/OpenJKDF2/archive/refs/tags/v$pkgver.tar.gz"
+    "openjkdf2.desktop")
+md5sums=('7c841a575cb1d64db6ddf0bd82c5bebb'
+         '41fab13ca2b0f4f379a1974bd6ba2517')
 
 build() {
-    echo "TODO"
+    cd "$srcdir/OpenJKDF2-$pkgver"
+    cmake .
+    make
 }
 
 package() {
-    echo "TODO"
+    cd "$srcdir/OpenJKDF2-$pkgver"
+    install -DT "openjkdf2-64" "$pkgdir/usr/bin/openjkdf2"
+    install -DTm644 "packaging/icon.png" "$pkgdir/usr/share/icons/hicolor/1024x1024/apps/$pkgname.png"
+    install -Dm644 -t "$pkgdir/usr/share/licenses/$pkgname" "LICENSE.md"
+    install -Dm644 -t "$pkgdir/usr/share/doc/$pkgname" "README.md"
+    install -Dm644 -t "$pkgdir/usr/share/doc/$pkgname/docs/images" "docs/images/"*
+    install -Dm644 -t "$pkgdir/usr/share/applications" "../$pkgname.desktop"
 }

--- a/packaging/linux/openjkdf2.desktop
+++ b/packaging/linux/openjkdf2.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=OpenJKDF2
+Comment=A cross-platform reimplementation of Jedi Knight: Dark Forces II
+Icon=openjkdf2
+Exec=openjkdf2
+Categories=Game;Shooter;

--- a/packaging/linux/openjkdf2.sh
+++ b/packaging/linux/openjkdf2.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+(cd /usr/share/openjkdf2 && ./openjkdf2-64 $@)

--- a/packaging/linux/openjkdf2_import.sh
+++ b/packaging/linux/openjkdf2_import.sh
@@ -1,0 +1,23 @@
+#! /bin/bash
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <gog_installer>"
+    exit
+fi
+gameid=$(innoextract -s --gog-game-id -- "$1")
+if [ "$gameid" != 1422286819 ]; then
+    echo "Specified file is not a JK:DF2 GOG installer" >&2
+    exit 1;
+fi
+tmpdir=$(mktemp -d)
+innoextract -q -d "$tmpdir" -I app/Resource -I app/MUSIC -I app/Episode -I app/player -I app/JK.EXE -- "$1"
+mv "$tmpdir/app/Resource"           "$tmpdir/app/resource"
+mv "$tmpdir/app/resource/VIDEO"     "$tmpdir/app/resource/video"
+mv "$tmpdir/app/resource/JK_.CD"    "$tmpdir/app/resource/jk_.cd"
+mv "$tmpdir/app/Episode"            "$tmpdir/app/episode"
+mv "$tmpdir/app/episode/JK1.GOB"    "$tmpdir/app/episode/JK1.gob"
+mv "$tmpdir/app/episode/JK1CTF.GOB" "$tmpdir/app/episode/JK1CTF.gob"
+mv "$tmpdir/app/episode/JK1MP.GOB"  "$tmpdir/app/episode/JK1MP.gob"
+sudo mkdir -p /usr/share/openjkdf2
+sudo cp -r "$tmpdir/app/"* /usr/share/openjkdf2
+rm -rf "$tmpdir"

--- a/packaging/linux/openjkdf2_import.sh
+++ b/packaging/linux/openjkdf2_import.sh
@@ -10,7 +10,7 @@ if [ "$gameid" != 1422286819 ]; then
     exit 1;
 fi
 tmpdir=$(mktemp -d)
-innoextract -q -d "$tmpdir" -I app/Resource -I app/MUSIC -I app/Episode -I app/player -I app/JK.EXE -- "$1"
+innoextract -q -d "$tmpdir" -I app/Resource -I app/MUSIC -I app/Episode -I app/JK.EXE -- "$1"
 mv "$tmpdir/app/Resource"           "$tmpdir/app/resource"
 mv "$tmpdir/app/resource/VIDEO"     "$tmpdir/app/resource/video"
 mv "$tmpdir/app/resource/JK_.CD"    "$tmpdir/app/resource/jk_.cd"


### PR DESCRIPTION
I thought I would practice my modest packaging skills on OpenJKDF2, but the results have been somewhat mixed. I consider this more an opportunity for discussion than something I expect to get merged, since such package definitions are impractical to keep in sync within the repository of the software they package.

As `openjkdf2-64` looks for the game data in the working directory and also attempts to _write_ to the working directory, running OpenJKDF2 requires write access to a normally root-owned directory if files are installed in their conventional locations. Still, this patch may prove useful if/when OpenJKDF2 is modified to write files to the user profile instead.

The included data importer is still more of a proof-of-concept, of course, but does extract all the needed files from the GOG installer.