### PR TITLE
Fix music looping issues

### DIFF
--- a/src/Cog/sithCogFunctionSound.c
+++ b/src/Cog/sithCogFunctionSound.c
@@ -8,14 +8,14 @@
 
 void sithCogFunctionSound_PlaySong(sithCog *ctx)
 {
-    int trackTo = sithCogVm_PopInt(ctx);
     int trackFrom = sithCogVm_PopInt(ctx);
+    int trackTo = sithCogVm_PopInt(ctx);
     int trackNum = sithCogVm_PopInt(ctx);
 
     if ( trackNum <= 0 )
         sithSoundSys_StopSong();
     else
-        sithSoundSys_PlaySong(trackTo, trackFrom, trackNum, 1);
+        sithSoundSys_PlaySong(trackFrom, trackTo, trackNum, 1);
 }
 
 void sithCogFunctionSound_PlaySoundThing(sithCog *ctx)

--- a/src/Dss/sithDSS.c
+++ b/src/Dss/sithDSS.c
@@ -765,8 +765,8 @@ void sithDSS_SendMisc(int sendto_id, int mpFlags)
     if ( sithSoundSys_bPlayingMci )
     {
         NETMSG_PUSHU8(sithSoundSys_dword_835FCC);
-        NETMSG_PUSHU8(sithSoundSys_trackTo);
         NETMSG_PUSHU8(sithSoundSys_trackFrom);
+        NETMSG_PUSHU8(sithSoundSys_trackTo);
     }
     
     NETMSG_END(COGMSG_ID_1F);
@@ -818,8 +818,8 @@ int sithDSS_HandleMisc(sithCogMsg *msg)
     if ( sithSoundSys_bPlayingMci )
     {
         sithSoundSys_dword_835FCC = NETMSG_POPU8();
-        sithSoundSys_trackTo = NETMSG_POPU8();
         sithSoundSys_trackFrom = NETMSG_POPU8();
+        sithSoundSys_trackTo = NETMSG_POPU8();
         sithSoundSys_ResumeMusic(1);
     }
 

--- a/src/Engine/sithSoundSys.c
+++ b/src/Engine/sithSoundSys.c
@@ -39,29 +39,29 @@ void sithSoundSys_Shutdown()
     }
 }
 
-int sithSoundSys_PlaySong(unsigned int trackTo, unsigned int trackFrom, unsigned int trackNum, int a4)
+int sithSoundSys_PlaySong(unsigned int trackFrom, unsigned int trackTo, unsigned int trackNum, int a4)
 {
-    unsigned int trackFrom_; // esi
-    unsigned int trackTo_; // edi
+    unsigned int trackTo_; // esi
+    unsigned int trackFrom_; // edi
     int result; // eax
 
     if ( sithSoundSys_bPlayingMci )
         stdMci_Stop();
-    trackFrom_ = trackFrom;
-    if ( trackFrom <= trackTo )
-        trackFrom_ = trackTo;
-    trackTo_ = trackNum;
-    if ( trackNum < trackTo )
+    trackTo_ = trackTo;
+    if (trackTo <= trackFrom)
+        trackTo_ = trackFrom;
+    trackFrom_ = trackNum;
+    if ( trackNum < trackFrom)
     {
-        trackTo_ = trackTo;
+        trackFrom_ = trackFrom;
     }
-    else if ( trackNum > trackFrom_ )
+    else if ( trackNum > trackTo_ )
     {
-        trackTo_ = trackFrom_;
+        trackFrom_ = trackTo_;
     }
-    sithSoundSys_trackTo = trackTo;
+    sithSoundSys_trackFrom = trackFrom;
     sithSoundSys_bPlayingMci = 1;
-    sithSoundSys_trackFrom = trackFrom_;
+    sithSoundSys_trackTo = trackTo_;
     sithSoundSys_dword_835FCC = a4;
     if ( !sithSoundSys_bIsMuted )
     {
@@ -71,7 +71,7 @@ int sithSoundSys_PlaySong(unsigned int trackTo, unsigned int trackFrom, unsigned
             stdMci_SetVolume(sithSoundSys_globalVolume);
         }
 
-        if ( !stdMci_Play(trackTo_, trackFrom_) )
+        if ( !stdMci_Play(trackFrom_, trackTo_) )
         {
             sithSoundSys_bPlayingMci = 0;
             return 0;
@@ -124,7 +124,7 @@ void sithSoundSys_UpdateMusicVolume(float musicVolume)
             if ( sithSoundSys_dword_835FCC )
             {
                 sithSoundSys_flt_835FD8 = sithTime_curSeconds - -5.0;
-                if ( !stdMci_CheckStatus() && !stdMci_Play(sithSoundSys_trackTo, sithSoundSys_trackFrom) )
+                if ( !stdMci_CheckStatus() && !stdMci_Play(sithSoundSys_trackFrom, sithSoundSys_trackTo) )
                 {
                     sithSoundSys_bPlayingMci = 0;
                     sithSoundSys_dword_835FCC = 0;
@@ -162,12 +162,14 @@ void sithSoundSys_ResumeMusic(int a1)
 {
     if ( sithSoundSys_bPlayingMci
       && !sithSoundSys_bIsMuted
+#ifndef QOL_IMPROVEMENTS
       && (a1 || sithControl_msIdle >= 0x7D0)
+#endif
       && sithSoundSys_dword_835FCC
       && (a1 || sithSoundSys_flt_835FD8 <= (double)sithTime_curSeconds) )
     {
         sithSoundSys_flt_835FD8 = sithTime_curSeconds - -5.0;
-        if ( !stdMci_CheckStatus() && !stdMci_Play(sithSoundSys_trackTo, sithSoundSys_trackFrom) )
+        if ( !stdMci_CheckStatus() && !stdMci_Play(sithSoundSys_trackFrom, sithSoundSys_trackTo) )
         {
             sithSoundSys_bPlayingMci = 0;
             sithSoundSys_dword_835FCC = 0;

--- a/src/Engine/sithSoundSys.h
+++ b/src/Engine/sithSoundSys.h
@@ -70,7 +70,7 @@ enum SITHSOUNDFLAG
 
 int sithSoundSys_Startup();
 void sithSoundSys_Shutdown();
-int sithSoundSys_PlaySong(unsigned int trackTo, unsigned int trackFrom, unsigned int trackNum, int a4);
+int sithSoundSys_PlaySong(unsigned int trackFrom, unsigned int trackTo, unsigned int trackNum, int a4);
 void sithSoundSys_StopSong();
 void sithSoundSys_UpdateMusicVolume(float musicVolume);
 void sithSoundSys_SetMusicVol(float volume);

--- a/src/Win95/stdMci.h
+++ b/src/Win95/stdMci.h
@@ -18,7 +18,7 @@
 
 int stdMci_Startup();
 void stdMci_Shutdown();
-int stdMci_Play(uint8_t trackTo, uint8_t trackFrom);
+int stdMci_Play(uint8_t trackFrom, uint8_t trackTo);
 void stdMci_SetVolume(float vol);
 void stdMci_Stop();
 int stdMci_CheckStatus();

--- a/symbols.syms
+++ b/symbols.syms
@@ -174,8 +174,8 @@ sithSoundSys_bOpened 0x00836BEC int
 sithSoundSys_pLastSectorSoundSector 0x00836BF4 sithSector*
 sithSoundSys_dword_836BF8 0x00836BF8 int
 sithSoundSys_dword_836BFC 0x00836BFC int
-sithSoundSys_trackTo 0x008BBC74 int
-sithSoundSys_trackFrom 0x008BBC70 int
+sithSoundSys_trackFrom 0x008BBC74 int
+sithSoundSys_trackTo 0x008BBC70 int
 sithSoundSys_pPlayingSoundIdk 0x00836BF8 sithPlayingSound*
 sithSoundSys_dword_836C00 0x00836C00 int
 sithSoundSys_nextSoundIdx 0x0054A684 int = 1


### PR DESCRIPTION
Music looping with SDL2 code is broken, resulting in music only repeating the first track of the level, unless the menu was open, in which case it plays through every track in the whole game.

This is basically caused by trackTo and trackFrom variables being labeled backwards in sithCogFunctionSound_PlaySong(), which propagated through sithSoundSys_PlaySong (resulting in nonsensical-seeming bounds checking logic in the decomp) and into the stdMci.c functions.

Everything still works (because we are sending the same numbers still) until we hit stdMci_trackFinished(), which was probably written assuming trackTo and trackFrom were labeled correctly, therefore it's currently acting on the wrong values. Also, stdMci_trackCurrent was never set, only incremented. And therefore the music never repeats properly.

I fixed it by swapping the names of trackTo and trackFrom throughout all the code, so that they are correctly labeled and all the logic makes sense. I made sure I didnt swap any function parameters around, so that each number is still being sent in the same order to each function, and the only logic changed is in stdMci_trackCurrent(). 

Though you might want to check symbols.syms to make sure the addresses for them are correct (if correct, the value of trackFrom should always be less than or equal to trackTo when music is playing) and update your ida project accordingly and double check that sithDSS.c uses them in the right order.


This patch:

- Swaps the variable names of trackTo and trackFrom in all its locations, sithSoundSys, stdMci, etc.
- Sets stdMci_trackCurrent in stdMci_Play() so that it has the correct value when reaching stdMci_trackFinished()
- Replaces  "go back to trackFrom" feature of stdMci_trackFinished() with a check to stop after trackTo is completed
	- This is because stdMci_trackFinished() didn't account for trackFrom being less than trackNum in sithCogFunctionSound_PlaySong and would make it start from trackNum when repeating every time. 
	- Now, once stdMci_trackFinished() stops, sithSoundSys_ResumeMusic() will see that playback stops after the first run and calls a new stdMci_Play() with the full range from trackFrom to trackTo, as per the original game.
- Now skips player controls idle check in sithSoundSys_ResumeMusic() as a QOL_FEATURE to restore the 'automatic repeat' intent of stdMci_trackFinished() so that music will automatically repeat without the player having to stand still a while.
	- I suspect this was supposed to be a check for music idle time rather than controls idle time and was a mistake by the original game devs, or maybe was supposed to stop repeating music if the player was idle rather than only repeat if the player was idle.

Thanks a bunch for this awesome work, the game (windows build of OpenJKDF2) plays great on Steam Deck so far :)