### PR TITLE
Corrected Flag Reference

### DIFF
--- a/src/AI/sithAI.c
+++ b/src/AI/sithAI.c
@@ -768,7 +768,7 @@ void sithAI_idk_msgarrived_target(sithActor *actor, float deltaSeconds)
         v9 = rdVector_Normalize3Acc(&actor->toMovePos);
         rdVector_Scale3(&tmp, &actor->toMovePos, actorb);
         actor->distToMovePos = v9;
-        if ( (v3->sector->flags & SITHAI_MODE_ATTACKING) == 0 && (v3->physicsParams.physflags & SITH_PF_FLY) == 0 )
+        if ( (v3->sector->flags & SITH_SECTOR_UNDERWATER) == 0 && (v3->physicsParams.physflags & SITH_PF_FLY) == 0 )
             tmp.z = 0.0;
         rdVector_Add3Acc(&tmp, &v3->physicsParams.vel);
         rdVector_Copy3(&v3->physicsParams.vel, &tmp);


### PR DESCRIPTION
Both `SITHAI_MODE_ATTACKING` and `SITH_SECTOR_UNDERWATER` have the value `0x2`, so likely was mixed up during decompilation.

It seems clear to me that:
1. The value it is checked against (`sector->flags`) ought to be a sector flag
2. The surrounding context makes sense for this to be an 'underwater' check