### PR TITLE
fix: add patch for bad idx causing an issue with randvec

### DIFF
--- a/src/Cog/sithCogExec.c
+++ b/src/Cog/sithCogExec.c
@@ -113,8 +113,17 @@ void sithCogExec_Exec(sithCog *cog_ctx)
                 if (!v12 )
                     break;
                 if (v12->val.type) {
-                    stdPlatform_Printf("OpenJKDF2: Script `%s` attempted to call `%s`, which doesn't exist...\n", cog_ctx->cogscript->cog_fpath, v12->field_18);
-                    break;
+                    // Altered: patch for bad idx value in tmpStackVar->data[0]; code will lookup cog fn by name;
+                    //          this addresses issue with a cog randvec sending in wrong idx id
+                    sithCogSymbol *tmpSithCogSymbol = sithCogParse_GetSymbolVal(sithCog_pSymbolTable, v12->field_18);
+                    // Need to verify for null, name match and type 
+                    if (tmpSithCogSymbol && !strcmp(tmpSithCogSymbol->field_18,v12->field_18) && !tmpSithCogSymbol->val.type ){
+                        //stdPlatform_Printf("OpenJKDF2: Script `%s` Patching call `%s\n", cog_ctx->cogscript->cog_fpath, tmpSithCogSymbol->field_18); 
+                        v12 = tmpSithCogSymbol;
+                    }else{
+                        stdPlatform_Printf("OpenJKDF2: Script `%s` attempted to call `%s`, which doesn't exist...\n", cog_ctx->cogscript->cog_fpath, v12->field_18);
+                        break;
+                    }
                 }
                 if ( v12->val.dataAsFunc ) {
                     //printf("OpenJKDF2: Script `%s` call `%s`\n", cog_ctx->cogscript->cog_fpath, v12->field_18);


### PR DESCRIPTION
Apply's a workaround for the `randvec` cog issues. 


### Summary
The `randvec` function [code](https://github.com/shinyquagsire23/OpenJKDF2/blob/master/src/Cog/sithCogFunction.c#L1751)  is implemented but for some reason when you right click with blaster weapons the value comes in incorrectly.  In base game it comes in as `15` 

when the value should be `256+ 2` where `256` is used to load `sithCog_pSymbolTable` and `2` comes from position in `sithCogFunction_Startup`. if Main_bMotsCompat is set would be would be `4`.

```
// On this call tmpStackVar->data[0] = 15 (would expect 258) 
v12 = sithCogParse_GetSymbol(cog_ctx->pSymbolTable, tmpStackVar->data[0]);
```

```c
void sithCogFunction_Startup(void* ctx)
{
    sithCogScript_RegisterVerb(ctx, sithCogFunction_Sleep, "sleep");
    if (Main_bMotsCompat) {
        sithCogScript_RegisterVerb(ctx, sithCogFunction_Pow, "pow"); // MOTS
        sithCogScript_RegisterVerb(ctx, sithCogFunction_Wakeup, "wakeup"); // MOTS
    }
    sithCogScript_RegisterVerb(ctx, sithCogFunction_Rand, "rand");
    sithCogScript_RegisterVerb(ctx, sithCogFunction_RandVec, "randvec");
```


When `randvec` fails on secondary fire, the AI / Player appear to go into aim bot mode as all secondary fire shots are a direct hit.  This behavior is  problematic when `Concussion Rifles`  are used on level 9 fuel station. 

### Fix Summary
To address this issue if the cog idx id is incorrect attempt to look up the function by name as a workaround.  

`v12->field_18` :  is the cog function name; `randvec` in this case

```c
if (v12->val.type) { // not 0 for function lookup
      // Altered: patch for bad idx value in tmpStackVar->data[0]; code will lookup cog fn by name;
      //          this addresses issue with a cog randvec sending in wrong idx id
      sithCogSymbol *tmpSithCogSymbol = sithCogParse_GetSymbolVal(sithCog_pSymbolTable, v12->field_18);
      // Need to verify for null, name match and type 
      if (tmpSithCogSymbol && !strcmp(tmpSithCogSymbol->field_18,v12->field_18) && !tmpSithCogSymbol->val.type ){
          //stdPlatform_Printf("OpenJKDF2: Script `%s` Patching call `%s\n", cog_ctx->cogscript->cog_fpath, tmpSithCogSymbol->field_18); 
          v12 = tmpSithCogSymbol;
      }else{
          stdPlatform_Printf("OpenJKDF2: Script `%s` attempted to call `%s`, which doesn't exist...\n", cog_ctx->cogscript->cog_fpath, v12->field_18);
          break;
      }
  }
```

 