### PR TITLE
Add See Also section linking to OpenJK

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,3 +343,7 @@ other          0.000%            0 / 107
 total          4.162%          105 / 2798
 
 ```
+
+## See Also
+
+- [OpenJK](https://github.com/JACoders/OpenJK) — Community-maintained open-source engine for Jedi Outcast (SP) and Jedi Academy (SP & MP), the sequels to Dark Forces II.


### PR DESCRIPTION
## Summary
- Add a small "See Also" section at the bottom of the README linking to [OpenJK](https://github.com/JACoders/OpenJK), the community engine for the Jedi Knight sequels (Jedi Outcast & Jedi Academy)

Helps users landing on this repo find the right project if they're looking for JO/JA instead of DF2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)