### PR TITLE
Add CMAKE_POLICY_VERSION_MINIMUM to remaining ExternalProject builds

### DIFF
--- a/cmake_modules/build_gns.cmake
+++ b/cmake_modules/build_gns.cmake
@@ -46,6 +46,7 @@ ExternalProject_Add(
                            -DProtobuf_USE_STATIC_LIBS:BOOL=TRUE
                            -DProtobuf_ROOT:PATH=${Protobuf_ROOT}
                            ${GAMENETWORKINGSOCKETS_PROTOC_EXECUTABLE}
+                           -DCMAKE_POLICY_VERSION_MINIMUM=3.5
                            ${GAMENETWORKINGSOCKETS_EXTRA_ARGS}
     DEPENDS                PROTOBUF ${GAMENETWORKINGSOCKETS_DEPENDS}
     PATCH_COMMAND          git restore CMakeLists.txt src/CMakeLists.txt &&

--- a/cmake_modules/build_host_zlib.cmake
+++ b/cmake_modules/build_host_zlib.cmake
@@ -36,6 +36,7 @@ ExternalProject_Add(
                         ${ZLIB_HOST_TOOLCHAIN_ARG}
                         -DCMAKE_INSTALL_LIBDIR=lib
                         -DCMAKE_BUILD_TYPE:STRING=Release
+                        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     BUILD_BYPRODUCTS    ${ZLIB_HOST_STATIC_LIBRARY_PATH} ${ZLIB_HOST_DYNAMIC_LIBRARY_PATH} ${ZLIB_HOST_IMPORT_LIBRARY_PATH}
 )
 

--- a/cmake_modules/build_libpng.cmake
+++ b/cmake_modules/build_libpng.cmake
@@ -33,6 +33,7 @@ ExternalProject_Add(
                         -DPNG_STATIC:BOOL=TRUE
                         -DPNG_EXECUTABLES:BOOL=FALSE
                         -DPNG_TESTS:BOOL=FALSE
+                        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
                         -DZLIB_ROOT:PATH=${ZLIB_ROOT}
     DEPENDS             ${LIBPNG_DEPENDS}
     BUILD_BYPRODUCTS    ${PNG_STATIC_LIBRARY_PATH} #${PNG_IMPORT_LIBRARY_PATH}

--- a/cmake_modules/build_protobuf.cmake
+++ b/cmake_modules/build_protobuf.cmake
@@ -126,6 +126,7 @@ ExternalProject_Add(
                            -Dprotobuf_BUILD_EXAMPLES:BOOL=FALSE
                            -Dprotobuf_BUILD_PROTOC_BINARIES:BOOL=${PROTOBUF_BUILD_PROTOC_BINARIES}
                            -Dprotobuf_DISABLE_RTTI:BOOL=TRUE
+                           -DCMAKE_POLICY_VERSION_MINIMUM=3.5
                            -DZLIB_ROOT:PATH=${ZLIB_ROOT}
     DEPENDS                ${PROTOBUF_DEPENDS} # add platform specific zlib depency
     BUILD_BYPRODUCTS       ${libprotobuf_STATIC_LIBRARY_PATH} ${libprotobuf_SHARED_LIBRARY_PATH}

--- a/cmake_modules/build_protoc.cmake
+++ b/cmake_modules/build_protoc.cmake
@@ -16,6 +16,7 @@ ExternalProject_Add(
                         -Dprotobuf_BUILD_EXAMPLES:BOOL=FALSE
                         -Dprotobuf_BUILD_PROTOC_BINARIES:BOOL=TRUE
                         -Dprotobuf_DISABLE_RTTI:BOOL=TRUE
+                        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
                         -DZLIB_ROOT:PATH=${ZLIB_HOST_ROOT}
     BUILD_COMMAND       ${CMAKE_MAKE_PROGRAM} protoc
     DEPENDS             ${PROTOC_DEPENDS}


### PR DESCRIPTION
## Summary
- Adds `CMAKE_POLICY_VERSION_MINIMUM=3.5` to 5 ExternalProject builds that were missing it: libpng, protobuf, protoc, host_zlib, and GameNetworkingSockets
- The other 7 build files (glew, physfs, openal, zlib, sdl, sdl_mixer, freeglut) already had this flag
- This prevents CMake 4 from rejecting old `cmake_minimum_required` versions in vendored submodules

Fixes #364

## Test plan
- [ ] Build with CMake 4.x on Arch Linux or similar
- [ ] Verify all ExternalProject dependencies configure without policy errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)