### PR TITLE
Fix saber bitmap palette in multiplayer menu

### DIFF
--- a/src/Gui/jkGUIBuildMulti.c
+++ b/src/Gui/jkGUIBuildMulti.c
@@ -773,6 +773,8 @@ void jkGuiBuildMulti_SaberDrawer(jkGuiElement *pElement, jkGuiMenu *pMenu, stdVB
     rdRect rect; // [esp+4h] [ebp-10h] BYREF
 
     pSabBm = jkGuiBuildMulti_apSaberBitmaps[jkGuiBuildMulti_saberIdx];
+    if (pSabBm->palette)
+        (*pSabBm->mipSurfaces)->palette = pSabBm->palette;
     rect.x = 0;
     rect.y = 0;
     bmWidth = (*pSabBm->mipSurfaces)->format.width;


### PR DESCRIPTION
## Summary
- Propagates the saber BM's embedded palette to its mipSurface before blitting in `jkGuiBuildMulti_SaberDrawer()`
- Without this, saber bitmaps inherit the UIColormap (purple UI scheme) palette, causing orange to render as purple and pink to display incorrectly

Fixes #432 (palette part — the in-engine pink saber material and `sabers.dat` entry are a separate data change)

## Approach

This is the minimal fix (**Option A**): set the palette on the mipSurface right before rendering in the saber drawer.

A broader fix (**Option B**) would propagate the bitmap palette to all mipSurfaces during `stdBitmap_LoadEntryFromFile` at load time. This is more correct in general but has a wider blast radius — other bitmap rendering paths may depend on the current behavior. Worth considering as a follow-up if other palette-dependent bitmaps have similar issues.

## Test plan
- [ ] Open MoTS multiplayer character creation menu
- [ ] Verify orange saber bitmap renders as orange (not purple)
- [ ] Verify other saber colors render correctly
- [ ] Verify 3D model preview still renders correctly (UIColormap unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)