### PR TITLE
Implement fileGetws for POSIX platforms

### DIFF
--- a/src/stdPlatform.c
+++ b/src/stdPlatform.c
@@ -16,7 +16,6 @@
 #include <time.h>
 #include <math.h>
 #include <string.h>
-#include <wchar.h>
 
 #include "external/fcaseopen/fcaseopen.h"
 #endif
@@ -183,7 +182,22 @@ static const char* Linux_stdFileGets(stdFile_t fhand, char* dst, size_t len)
 
 static const wchar_t* Linux_stdFileGetws(stdFile_t fhand, wchar_t* dst, size_t len)
 {
-    return fgetws(dst, len, (FILE*)fhand);
+    // Can't use fgetws because -fshort-wchar makes wchar_t 2 bytes
+    // but libc fgetws expects native wchar_t (4 bytes on POSIX).
+    // Read UTF-16LE characters one at a time instead.
+    if (!len) return NULL;
+    size_t i = 0;
+    while (i < len - 1) {
+        wchar_t ch = 0;
+        if (fread(&ch, sizeof(wchar_t), 1, (FILE*)fhand) != 1) {
+            if (i == 0) return NULL;
+            break;
+        }
+        dst[i++] = ch;
+        if (ch == L'\n') break;
+    }
+    dst[i] = L'\0';
+    return dst;
 }
 
 static int Linux_stdFseek(stdFile_t fhand, int a, int b)

--- a/src/stdPlatform.c
+++ b/src/stdPlatform.c
@@ -16,6 +16,7 @@
 #include <time.h>
 #include <math.h>
 #include <string.h>
+#include <wchar.h>
 
 #include "external/fcaseopen/fcaseopen.h"
 #endif
@@ -178,6 +179,11 @@ static const char* Linux_stdFileGets(stdFile_t fhand, char* dst, size_t len)
 #else
     return fgets(dst, len, (FILE*)fhand);
 #endif
+}
+
+static const wchar_t* Linux_stdFileGetws(stdFile_t fhand, wchar_t* dst, size_t len)
+{
+    return fgetws(dst, len, (FILE*)fhand);
 }
 
 static int Linux_stdFseek(stdFile_t fhand, int a, int b)
@@ -714,6 +720,7 @@ void stdPlatform_InitServices(HostServices *handlers)
     handlers->fileRead = Linux_stdFileRead;
     handlers->fileGets = Linux_stdFileGets;
     handlers->fileWrite = Linux_stdFileWrite;
+    handlers->fileGetws = Linux_stdFileGetws;
     handlers->fseek = Linux_stdFseek;
     handlers->ftell = Linux_stdFtell;
     handlers->getTimerTick = Linux_TimeMs;


### PR DESCRIPTION
## Summary
- Adds `Linux_stdFileGetws()` wrapping `fgetws()` and assigns it to `handlers->fileGetws` in the POSIX platform init
- The function pointer was never assigned for POSIX, causing NULL pointer calls when `stdStrTable_ParseUniLine()` tries to load `.uni` string tables
- This broke text rendering in menus on Linux after commit 9c680121 added the `ParseUniLine` decompilation

Fixes #386, likely also resolves #387 (player error message was unreadable due to missing strings)

## Test plan
- [ ] Build on Linux
- [ ] Verify menu text renders correctly
- [ ] Verify `.uni` string tables load without "Premature END" errors in log

🤖 Generated with [Claude Code](https://claude.com/claude-code)