### PR TITLE
Remove forward-compatible GL flag on Linux to fix Steam Deck GLX error

### DIFF
--- a/src/Win95/Window.c
+++ b/src/Win95/Window.c
@@ -1374,7 +1374,6 @@ void Window_RecreateSDL2Window()
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
         SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG);
         glWindowContext = SDL_GL_CreateContext(displayWindow);
     }
     
@@ -1474,7 +1473,6 @@ int Window_Main_Linux(int argc, char** argv)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
     SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG);
 #endif
 
 #endif


### PR DESCRIPTION
## Summary
- Removes `SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG` from the generic Linux GL attribute setup and the GL 3.3 context retry path
- This flag causes "Couldn't find matching GLX visual" on Mesa/AMD drivers (Steam Deck), preventing the game from launching
- The flag is unnecessary in Core profile contexts — it only has meaning in Compatibility profile to disable deprecated features
- The `WIN64_STANDALONE` path retains the flag since Windows drivers handle it fine

Fixes #409

## Test plan
- [ ] Verify the game launches on Steam Deck (Flatpak version)
- [ ] Verify GL rendering still works correctly on desktop Linux (Mesa and NVIDIA)
- [ ] Verify Windows builds are unaffected (flag still set on WIN64_STANDALONE path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)