### PR TITLE
ci: add autobuild artifacts on master push

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
       name: Checkout
@@ -27,3 +27,10 @@ jobs:
           brew install openssl@3 protobuf
     - name: cmake
       run: export HOMEBREW_PREFIX="/usr/local" && ./.github/build_macos.sh
+    - name: Upload Artifact
+      if: github.event_name == 'push'
+      uses: actions/upload-artifact@v4
+      with:
+        name: openjkdf2-macos
+        path: build_darwin64/OpenJKDF2.app
+        if-no-files-found: warn

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   pull_request:
-    branches: 
+    branches:
       - master
 
 jobs:
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      OPENJKDF2_BUILD_DIR: /tmp/OpenJKDF2/Linux/x86_64/Debug
+      OPENJKDF2_BUILD_DIR: /tmp/OpenJKDF2/Linux/x86_64/Release
       CC: clang
       CXX: clang++
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
         name: Checkout
@@ -30,6 +30,15 @@ jobs:
                                   protobuf-compiler &&
           sudo pip3 install cogapp
       - name: Generate CMake Build System
-        run: cmake -DCMAKE_BUILD_TYPE=Debug -B "$OPENJKDF2_BUILD_DIR"
+        run: cmake -DCMAKE_BUILD_TYPE=Release -B "$OPENJKDF2_BUILD_DIR"
       - name: Make
-        run: make -C "$OPENJKDF2_BUILD_DIR"
+        run: make -C "$OPENJKDF2_BUILD_DIR" -j $(nproc)
+      - name: Upload Artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: openjkdf2-linux-x86_64
+          path: |
+            ${{ env.OPENJKDF2_BUILD_DIR }}/openjkdf2
+            ${{ env.OPENJKDF2_BUILD_DIR }}/libGameNetworkingSockets.so
+          if-no-files-found: warn

--- a/.github/workflows/win64.yml
+++ b/.github/workflows/win64.yml
@@ -2,7 +2,7 @@ name: Windows SDL2
 
 on:
   push:
-    branches: 
+    branches:
       - master
   pull_request:
     branches:
@@ -16,7 +16,7 @@ jobs:
     env:
       OPENJKDF2_BUILD_DIR: /tmp/OpenJKDF2
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
         name: Checkout
@@ -33,7 +33,21 @@ jobs:
       - name: Generate CMake Build System
         run: |
           cmake --toolchain cmake_modules/toolchain_mingw.cmake \
-                -DCMAKE_BUILD_TYPE=Debug -DGITHUB_RUNNER_COMPILE=1 \
+                -DCMAKE_BUILD_TYPE=Release -DGITHUB_RUNNER_COMPILE=1 \
                 -B "$OPENJKDF2_BUILD_DIR"
       - name: Make
         run: make -C "$OPENJKDF2_BUILD_DIR" -j $(nproc)
+      - name: Upload Artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: openjkdf2-windows-x86_64
+          path: |
+            ${{ env.OPENJKDF2_BUILD_DIR }}/openjkdf2-64.exe
+            ${{ env.OPENJKDF2_BUILD_DIR }}/OpenAL32.dll
+            ${{ env.OPENJKDF2_BUILD_DIR }}/libGameNetworkingSockets.dll
+            ${{ env.OPENJKDF2_BUILD_DIR }}/exchndl.dll
+            ${{ env.OPENJKDF2_BUILD_DIR }}/symsrv.dll
+            ${{ env.OPENJKDF2_BUILD_DIR }}/mgwhelp.dll
+            ${{ env.OPENJKDF2_BUILD_DIR }}/symsrv.yes
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` v3 → v4 and add `actions/upload-artifact` v4
- Switch CI builds from Debug → Release so artifacts are usable
- Upload build artifacts (binaries + bundled shared libs) on master push for all 3 platforms:
  - **Linux**: `openjkdf2` + `libGameNetworkingSockets.so`
  - **Windows**: `openjkdf2-64.exe` + `OpenAL32.dll`, `libGameNetworkingSockets.dll`, drmingw crash handler DLLs
  - **macOS**: `OpenJKDF2.app` bundle
- Artifacts are only uploaded on push to master (not on PRs) to save storage

This lets users grab working builds directly from the Actions tab without building from source.

## Test plan
- [ ] Verify Linux workflow uploads artifact on master push
- [ ] Verify Windows workflow uploads artifact on master push
- [ ] Verify macOS workflow uploads artifact on master push
- [ ] Verify PR builds still work (no artifact upload, just build check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)