### PR TITLE
Fix nix flake for SDL3_mixer migration, drop the verbose flake ref, add CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,39 @@
+name: Nix Flake
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    # Builds SDL3, OpenAL, protobuf and friends from source; expect 30-90+ min.
+    timeout-minutes: 180
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          # The git+file: fetcher below re-resolves the repo from git history;
+          # a shallow clone (checkout's default depth 1) is not enough for it.
+          fetch-depth: 0
+        name: Checkout
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      # ?submodules=1 is mandatory and is the invocation documented in flake.nix:
+      # a bare .#default resolves the git tree WITHOUT submodules, and the build
+      # then dies in build_glew.cmake with "No download info given for 'GLEW'".
+      # TODO: add binary caching (actions/cache on /nix/store) if CI time hurts.
+      - name: Build
+        run: nix build 'git+file:.?submodules=1#default' --print-build-logs
+      - name: Verify Binary
+        run: test -x result/bin/openjkdf2

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -27,13 +27,16 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v27
         with:
+          # inputs.self.submodules in flake.nix needs Nix >= 2.28; pin so the
+          # action's default version can't silently drop below that.
+          install_url: https://releases.nixos.org/nix/nix-2.34.8/install
           extra_nix_config: |
             experimental-features = nix-command flakes
-      # ?submodules=1 is mandatory and is the invocation documented in flake.nix:
-      # a bare .#default resolves the git tree WITHOUT submodules, and the build
-      # then dies in build_glew.cmake with "No download info given for 'GLEW'".
+      # Builds the bare ref on purpose: inputs.self.submodules in flake.nix is
+      # what makes this fetch submodules, and that is the invocation the header
+      # comment tells users to run, so it is the one worth regression-testing.
       # TODO: add binary caching (actions/cache on /nix/store) if CI time hurts.
       - name: Build
-        run: nix build 'git+file:.?submodules=1#default' --print-build-logs
+        run: nix build --print-build-logs
       - name: Verify Binary
         run: test -x result/bin/openjkdf2

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,18 @@
-# Build:  nix build 'git+file:.?submodules=1'
-# Shell:  nix develop 'git+file:.?submodules=1'
-# The ?submodules=1 is required because the build uses vendored deps from
-# git submodules (SDL2, OpenAL, zlib, libpng, GLEW, PhysFS, freeglut).
+# Build:  nix build
+# Shell:  nix develop
+#
+# The build uses vendored deps from git submodules (SDL, OpenAL, zlib,
+# libpng, GLEW, PhysFS, freeglut). `inputs.self.submodules = true` below
+# makes a bare `.` flake ref fetch them, so no ?submodules=1 is needed.
+#
+# Requires Nix >= 2.28. On Lix, `self` attributes are gated behind an
+# experimental feature and evaluation fails without it:
+#   nix build --extra-experimental-features flake-self-attrs
 {
   description = "OpenJKDF2 - Function-by-function reimplementation of Jedi Knight: Dark Forces II";
 
   inputs = {
+    self.submodules = true;
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
           libGLU
           glew
 
-          # X11 (SDL2 compile-time headers)
+          # X11 (SDL3 compile-time headers)
           libx11
           libxext
           libxcursor
@@ -38,8 +38,12 @@
           libxrandr
           libxscrnsaver
           libxxf86vm
+          # SDL3 (unlike SDL2) hard-requires XTEST and Xfixes for its X11 backend
+          # and errors out at configure time if they're missing.
+          libxtst
+          libxfixes
 
-          # Wayland (SDL2 compile-time)
+          # Wayland (SDL3 compile-time)
           wayland
           wayland-protocols
           wayland-scanner
@@ -95,8 +99,8 @@
                 --replace-fail 'set(TARGET_USE_GAMENETWORKINGSOCKETS TRUE)' \
                                'set(TARGET_USE_GAMENETWORKINGSOCKETS FALSE)'
               substituteInPlace cmake_modules/build_sdl_mixer.cmake \
-                --replace-fail '-DSDL2MIXER_VENDORED:BOOL=TRUE' \
-                               '-DSDL2MIXER_VENDORED:BOOL=FALSE'
+                --replace-fail '-DSDLMIXER_VENDORED:BOOL=TRUE' \
+                               '-DSDLMIXER_VENDORED:BOOL=FALSE'
               # When using system ogg/vorbis/opus, the vendored static lib paths
               # from SDL_MIXER_DEPS don't exist. Replace the entire if/else block
               # with a simple set. Use ''$ to produce literal $ in nix strings.


### PR DESCRIPTION
The nix flake added in #422 no longer builds against current master, due to drift from the SDL2_mixer → SDL3_mixer migration. This fixes it, then adds CI so it can't rot again silently.

### 1. The break

SDL3_mixer renamed the vendoring option from `SDL2MIXER_VENDORED` to `SDLMIXER_VENDORED` (`cmake_modules/build_sdl_mixer.cmake:118`). The flake's `postPatch` pins the old name with `--replace-fail`, so the build aborts in `patchPhase`:

```
substituteStream() in derivation openjkdf2-0.9.8: ERROR: pattern
-DSDL2MIXER_VENDORED:BOOL=TRUE doesn't match anything in file
'cmake_modules/build_sdl_mixer.cmake'
```

The other two `--replace-fail` patterns — the `SDL_MIXER_DEPS` if/else block and `TARGET_USE_GAMENETWORKINGSOCKETS` — were checked byte-for-byte against current sources and had **not** drifted. All three stay `--replace-fail` rather than `--replace`, so future drift keeps failing loudly instead of silently no-op'ing.

Also adds `libxtst` and `libxfixes` to `systemDeps`: SDL3's `CheckX11` hard-errors at configure time when XTEST or Xfixes are missing, where SDL2 degraded gracefully. `-DSDL_X11_XTEST=OFF` would silently drop functionality, so pulling in the packages is the better fix.

### 2. CI

Adds `.github/workflows/nix.yml`. The flake merged in #422, then ~247 commits went by and broke it with nobody noticing, because none of the three existing workflows evaluate it. This job builds the bare ref — the invocation the header now documents, and the one that actually exercises `inputs.self.submodules`.

Nix is pinned to 2.34.8 rather than left to `install-nix-action`'s default, so CI can't fail merely because the default drifted below the 2.28 floor. Binary caching is left as a `TODO`; the build compiles SDL3, OpenAL and protobuf from source, so expect it to be slow (`timeout-minutes: 180`).

### Verification

Local `nix build` produces a working `result/bin/openjkdf2` (6.2 MB). `ldd` confirms the pkg-config swap resolves ogg/vorbis/vorbisfile/opus/opusfile to nix store paths, with SDL3 statically linked as intended.

The vendoring is disabled at all (unchanged from #422, restated for context) because SDL_mixer's vendored ogg/vorbis/opus/opusfile are *nested* submodules that nix's flake source fetch doesn't pull, so the flake forces `VENDORED=FALSE` and wires in system codecs via pkg-config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
