### PR TITLE
ci: SDL3 naming, drop unused SDL2 packages, bump runners

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
       name: Checkout

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: MacOS SDL2
+name: MacOS SDL3
 
 on:
   push:
@@ -23,7 +23,7 @@ jobs:
           brew upgrade && brew install --overwrite python3
           brew install cmake make imagemagick
           pip3 install --break-system-packages cogapp generate-iconset
-          brew install openal-soft sdl2 sdl2_mixer glew libmodplug libpng
+          brew install openal-soft glew libmodplug libpng
           brew install openssl@3 protobuf
     - name: cmake
       run: export HOMEBREW_PREFIX="/usr/local" && ./.github/build_macos.sh

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 22.04 SDL3
+name: Ubuntu 24.04 SDL3
 
 on:
   push:
@@ -11,14 +11,14 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     env:
       OPENJKDF2_BUILD_DIR: /tmp/OpenJKDF2/Linux/x86_64/Debug
       CC: clang
       CXX: clang++
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
         name: Checkout

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,7 +27,10 @@ jobs:
           sudo apt-get update -qq &&
           sudo apt-get install -y build-essential cmake make clang python3 python3-pip bison imagemagick zsh \
                                   libgtk-3-dev libopenal-dev libglew-dev libssl-dev libprotobuf-dev libpng-dev libcurl4-openssl-dev \
-                                  protobuf-compiler &&
+                                  protobuf-compiler \
+                                  libx11-dev libxext-dev libxcursor-dev libxinerama-dev libxi-dev libxrandr-dev \
+                                  libxss-dev libxxf86vm-dev libxtst-dev libxfixes-dev libxkbcommon-dev \
+                                  libwayland-dev wayland-protocols libasound2-dev libpulse-dev libdbus-1-dev libudev-dev &&
           sudo pip3 install cogapp
       - name: Generate CMake Build System
         run: cmake -DCMAKE_BUILD_TYPE=Debug -B "$OPENJKDF2_BUILD_DIR"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 22.04 SDL2
+name: Ubuntu 22.04 SDL3
 
 on:
   push:
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt-get update -qq &&
           sudo apt-get install -y build-essential cmake make clang python3 python3-pip bison imagemagick zsh \
-                                  libgtk-3-dev libsdl2-dev libsdl2-mixer-dev libopenal-dev libglew-dev libssl-dev libprotobuf-dev libpng-dev libcurl4-openssl-dev \
+                                  libgtk-3-dev libopenal-dev libglew-dev libssl-dev libprotobuf-dev libpng-dev libcurl4-openssl-dev \
                                   protobuf-compiler &&
           sudo pip3 install cogapp
       - name: Generate CMake Build System

--- a/.github/workflows/win64.yml
+++ b/.github/workflows/win64.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       OPENJKDF2_BUILD_DIR: /tmp/OpenJKDF2
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
         name: Checkout

--- a/.github/workflows/win64.yml
+++ b/.github/workflows/win64.yml
@@ -1,4 +1,4 @@
-name: Windows SDL2
+name: Windows SDL3
 
 on:
   push:


### PR DESCRIPTION
CI hygiene for the SDL3 migration: correct the workflow names, replace an accidental dependency with an explicit one, and bump the stale runner.

### The names say SDL2; nothing here builds SDL2

- `cmake_modules/build_sdl.cmake` sets `SDL_VERSION 3.4.12`, links `libSDL3`, includes `include/SDL3`
- the `lib/SDL` submodule is pinned to `release-3.4.12`
- SDL3 is compiled from that submodule via `ExternalProject` on every platform

The names are leftovers from before the migration, and they mislead — someone checking which SDL this project targets currently finds three green checks all claiming SDL2.

### The SDL2 dev packages, and what they were actually doing

`ubuntu.yml` installed `libsdl2-dev libsdl2-mixer-dev`; `macos.yml` installed `sdl2 sdl2_mixer`. Neither is used *as SDL* — `build_sdl.cmake` replicates the `FindSDL` variables itself and points them at the vendored tree, so the system SDL is never linked.

**But on Linux `libsdl2-dev` was load-bearing anyway**, and I got this wrong on the first pass. Its dependency closure supplies `libxss-dev`, `libxinerama-dev`, `libasound2-dev` and the rest of the X11/audio dev headers — which the vendored *SDL3* build genuinely requires. Removing it broke the build in SDL3's own `CheckX11`:

```
CMake Error at cmake/macros.cmake:433 (message):
  Couldn't find dependency package for XSCRNSAVER.
Call Stack (most recent call first):
  cmake/sdlchecks.cmake:531 (SDL_missing_dependency)
  CMakeLists.txt:1826 (CheckX11)
```

So the third commit declares those packages directly instead of restoring `libsdl2-dev` to smuggle them in. The list mirrors `systemDeps` in `flake.nix`, which is a known-good dependency set for building this same vendored SDL3. That trades an accidental, undocumented dependency for an explicit one — arguably the most useful change in this PR, and the reason the SDL2 removal is worth keeping rather than reverting.

macOS needed no equivalent: Homebrew's `sdl2` formula isn't a header-dependency hub the way Debian's `-dev` package is, and that job passes with it removed.

### Runner and action bump

`ubuntu.yml` was the last workflow pinned to `ubuntu-22.04`. `win64.yml` already runs on `ubuntu-24.04`, so 24.04 is proven against this repo's toolchain rather than a speculative jump. No workflow uploads release artifacts, so there's no glibc-compatibility reason to hold the older image back — if that changes when #437 lands, the artifact job is the one that should pin, not the build jobs.

Also bumps `actions/checkout` v3 → v4 across all three; v3 runs on Node 16, which GitHub has deprecated and warns about on every run.

### Not in scope

`plat_feat_full_sdl2.cmake`, `TARGET_USE_SDL2` and `SDL2_COMMON_LIBS` are stale in the same way. Left alone because that file is referenced **by path** from the nix flake's `postPatch` (`substituteInPlace cmake_modules/plat_feat_full_sdl2.cmake`), so renaming it has to land in lockstep with a flake change. Happy to follow up once #456 settles.

> [!NOTE]
> Renaming a workflow changes the check name GitHub reports. These PR checks still display the old `... SDL2` names, since GitHub takes the display name from the base branch's workflow file — so the rename only takes effect on merge to `master`. If any branch-protection rule requires the old names, it needs updating at that point or it will block on checks that no longer exist.

All three jobs pass on the current head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
